### PR TITLE
Clean-up

### DIFF
--- a/src/_data/taglist.js
+++ b/src/_data/taglist.js
@@ -5,7 +5,7 @@ const CMS = process.env.CMS;
 module.exports = async function () {
   console.log("Making fetch happen...");
 
-  return fetch(CMS + "/wp-json/wp/v2/tags?_fields=id,slug,name")
+  return fetch(CMS + "/wp-json/wp/v2/tags?_fields=id,slug,name&per_page=100")
     .then((res) => res.json())
     .then((json) => json);
 };

--- a/src/_includes/layouts/blog-single.html
+++ b/src/_includes/layouts/blog-single.html
@@ -16,7 +16,7 @@
     {% endif %}
 
     <div class="reading flow e-content">
-      {{ posts.content.rendered | replace(env.CMS, '') | replace(env.MEDIAPATH, env.IMAGEPATH) | safe  }}
+      {{ posts.content.rendered | replace(env.CMS, '') | replace(env.MEDIAPATH, env.IMAGEPATH) | safe }}
     </div>
     <div hidden>
       <a href="{{ site.url }}{{ page.url }}" class="u-url">{{ posts.title.rendered | safe }}</a>

--- a/src/_includes/partials/tags.html
+++ b/src/_includes/partials/tags.html
@@ -2,7 +2,7 @@
         <ul class="tag-list" role="list">
           {% for tag in posts.tags %}
             {% for tagName in taglist %}
-              {% if tag == tagName.id %}
+              {% if tag === tagName.id %}
               <li>
                 <a href="/tag/{{ tagName.slug }}">{{ tagName.name }}</a>
               </li>

--- a/src/blog-single.md
+++ b/src/blog-single.md
@@ -1,13 +1,11 @@
 ---
 layout: 'layouts/blog-single.html'
-summary: 'The latest and greatest in the Junk Drawer.'
 pagination:
   data: posts
   size: 1
   alias: posts
   addAllPagesToCollections: true
 permalink: "blog/{{ posts.slug }}/"
-templateOverrideEngine: md, njk
 eleventyComputed:
   title: "{{ posts.title.rendered | safe }}"
   summary: "{{ posts.acf.summary | safe }}"


### PR DESCRIPTION
Cleaning up a few small bits

* Added pagination to the tags endpoint call
* Removed an extra space in the single blog post template
* Updated to tag equivalency check when matching tag ids between the posts and tags endpoints
* Removed the summary and templateOverrideEngine from single blog post markdown